### PR TITLE
change if-condition in robot.go

### DIFF
--- a/robot.go
+++ b/robot.go
@@ -63,7 +63,7 @@ func (bot *robot) RegisterEventHandler(f framework.HandlerRegitster) {
 }
 
 func (bot *robot) handlePREvent(e *sdk.PullRequestEvent, c config.Config, log *logrus.Entry) error {
-	if e.GetPullRequest().GetState() != "open" {
+	if e.GetPullRequest().GetState() != "opened" && e.GetPullRequest().GetState() != "open" {
 		return nil
 	}
 


### PR DESCRIPTION
resolve bug that can't add cla-label when pr is opened, because of gitee returns two types of pr state